### PR TITLE
EPMRPP-98686 || fix parent mapping

### DIFF
--- a/src/main/java/com/epam/reportportal/extension/bugtracking/jira/JIRATicketUtils.java
+++ b/src/main/java/com/epam/reportportal/extension/bugtracking/jira/JIRATicketUtils.java
@@ -147,6 +147,10 @@ public class JIRATicketUtils {
         issueUpdateDetails.putFieldsItem(IssueField.FIX_VERSIONS_FIELD.value, versions);
         continue;
       }
+      if (one.getId().equalsIgnoreCase(IssueField.PARENT_FIELD.value) && !one.getValue().isEmpty()) {
+        issueUpdateDetails.putFieldsItem(IssueField.PARENT_FIELD.value, Map.entry("key", one.getValue().get(0)));
+        continue;
+      }
 
       var cimFieldInfo = fieldsMap.get(one.getId());
       // Arrays and fields with 'allowedValues' handler


### PR DESCRIPTION
This pull request adds a new condition to handle the parent field in the `toIssueInput` method of `JIRATicketUtils.java`. The most important change is the addition of a check for the parent field and the corresponding logic to update the `issueUpdateDetails` with the parent field's value.

* [`src/main/java/com/epam/reportportal/extension/bugtracking/jira/JIRATicketUtils.java`](diffhunk://#diff-dfa70c66d5b4f8d69fda81200cc7269c1cef8f9a859592237ebfb6794a87c55aR150-R153): Added a condition to check if the field is the parent field and if it has a non-empty value, then updated the `issueUpdateDetails` with the parent field's key and value.